### PR TITLE
feature/MB-37 Add upload image API and frontend support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,87 @@
+name: 🚀 CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: 🔍 Lint & Code Quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+
+  test:
+    name: 🧪 Unit Tests (Jest)
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test -- --ci --passWithNoTests
+
+  build:
+    name: 🏗️ Build Check
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+        env:
+          NODE_ENV: production
+
+  deploy:
+    name: 🚀 Deploy to Production
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            export TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }}
+            export TELEGRAM_CHAT_ID=${{ secrets.TELEGRAM_CHAT_ID }}
+            cd ${{ secrets.PROJECT_DIR }}
+            bash test_deploy.sh
+
+  healthcheck:
+    name: 💓 Health Check
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Wait for app to start
+        run: sleep 15
+      - name: Check site is responding
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" ${{ secrets.PROD_URL }})
+          echo "HTTP Status: $STATUS"
+          if [ "$STATUS" != "200" ]; then
+            echo "❌ Health check failed! Status: $STATUS"
+            exit 1
+          fi
+          echo "✅ Site is up and responding!"
+      - name: Notify Telegram on failure
+        if: failure()
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d "text=❌ Health check неуспешен! Провери: ${{ secrets.PROD_URL }}"

--- a/AI-ask-answer/docs/plan-upload-images-api.md
+++ b/AI-ask-answer/docs/plan-upload-images-api.md
@@ -1,0 +1,71 @@
+# План: API за upload снимки и показване в блога
+
+## Контекст
+
+- В базата се записват пътища като `/upload/1767370010013.png` (главна снимка и снимка по секции).
+- Docker volume монтира host папката в контейнера като `/app/upload` (виж `docker-compose.yml`).
+- `getArticles` вече връща `images` и за всяка секция `image_url`; `getArticlesSlice` запазва `article.images` и `article.sections[].image_url`.
+- В момента карточките използват статична снимка; в страницата за четене секциите нямат показвана снимка.
+
+## Поток
+
+```mermaid
+flowchart LR
+  DB["DB: /upload/xxx.png"] --> GetArticles["getArticles API"]
+  GetArticles --> Redux["Redux (article.images, section.image_url)"]
+  Redux --> Cards["CardAquariumsHTML"]
+  Redux --> Read["ReadHTML"]
+  Cards --> Img["img src=/api/upload/xxx.png"]
+  Read --> Img
+  Img --> ApiRoute["GET /api/upload/[...path]"]
+  ApiRoute --> FS["upload/ (volume)"]
+```
+
+## Стъпки
+
+### 1. API route за обслужване на файлове от `upload/`
+
+- **Файл:** `app/api/upload/[...path]/route.ts` (нов).
+- Логика:
+  - При GET: взема `path` от `params` (масив от сегменти), прави безопасен файлов път с `path.join(process.cwd(), 'upload', ...path)`.
+  - Проверка за directory traversal: отхвърляне на сегменти съдържащи `..` или празни; при невалиден path връща 400.
+  - Чете файла с `fs.createReadStream` (или `fs.promises.readFile`) и го връща с подходящ `Content-Type` (напр. по разширение: `.png` -> `image/png`, `.jpg`/`.jpeg` -> `image/jpeg`, `.webp` -> `image/webp`). При липсващ файл връща 404.
+  - Заглавки: `Cache-Control` (напр. `public, max-age=86400`) за кеширане.
+
+За Docker: `process.cwd()` в контейнера е работната директория на приложението (напр. `/app`), така че `path.join(process.cwd(), 'upload', filename)` съответства на монтирания volume.
+
+### 2. Помощна функция за URL на снимка (препоръчително)
+
+- **Файл:** например `app/Helper-components/utils/imageUrl.js` или в съществуващ helper файл (ако има такъв).
+- Функция: `getUploadImageUrl(path)` – ако `path` е не-празен стринг и започва с `/upload/`, връща `/api/upload/` + името на файла (без `/upload/`); иначе връща `null` или празен стринг. Така фронтендът не дублира логиката.
+
+### 3. CardAquariumsHTML – главна снимка на статията
+
+- **Файл:** `app/cardAquariums/CardAquariumsHTML.jsx`.
+- В картата за статия се използва `style={{ backgroundImage: \`url(${img[7].url.src})\` }}` (ред ~74).
+- Промяна: изчисляване на `imageUrl = getUploadImageUrl(article.images) || img[7].url.src` и използване на `url(${imageUrl})` за `backgroundImage`, така че при наличен `article.images` да се ползва снимката от upload, иначе fallback към текущата статична.
+
+### 4. ReadHTML – снимка за всяка секция
+
+- **Файл:** `app/ReadArticles/ReadHTML.jsx`.
+- В цикъла по секции (ред ~146–152) се рендерират само заглавие и съдържание.
+- Промяна: за всяка секция, ако има `section.image_url`, преди или след заглавието да се рендерира `<img src={getUploadImageUrl(section.image_url)} alt={section.title} />` с подходящ клас (напр. съществуващите в `read.scss` за `.article-data img`). При липса на `image_url` да не се показва img.
+
+### 5. Опционално: главна снимка в страницата за четене
+
+- Ако искате главна снимка на статията в ReadHTML (отгоре), може да се използва първата налична от `article.images` (от Redux за текущата статия) със същата `getUploadImageUrl`. Това може да е отделна малка стъпка след 4.
+
+## Файлове за промяна/създаване
+
+| Действие | Файл |
+|----------|------|
+| Създаване | `app/api/upload/[...path]/route.ts` |
+| Създаване (или в съществуващ helper) | Helper за `getUploadImageUrl` |
+| Редакция | `app/cardAquariums/CardAquariumsHTML.jsx` |
+| Редакция | `app/ReadArticles/ReadHTML.jsx` |
+
+## Забележки
+
+- Не се променя `getArticles` – данните остават в DB формат (`/upload/xxx.png`); преобразуването е само при показване на фронтенда.
+- Ако в бъдеще в схемата има отделно поле за главна снимка на статия (напр. `articles.main_image_url`), в `getArticles/route.ts` трябва да се взима то и да се мапва на `images` вместо от първата секция; текущият план не променя заявката.
+- Сигурност: API route да не приема `..` в path и да чете само от поддиректорията `upload/`.

--- a/AI-ask-answer/docs/plans.md
+++ b/AI-ask-answer/docs/plans.md
@@ -7,3 +7,4 @@
 ## Планове
 
 - **[GitHub Actions (self-hosted) – деплой при push в master](./plan-github-actions-master-deploy.md)** – автоматично пускане на `test_deploy.sh` при push в `master` чрез self-hosted runner.
+- **[API за upload снимки и показване в блога](./plan-upload-images-api.md)** – API route за обслужване на снимки от `upload/`, показване в карточките и в страницата за четене на статия.

--- a/app/Helper-components/utils/imageUrl.js
+++ b/app/Helper-components/utils/imageUrl.js
@@ -1,0 +1,13 @@
+/**
+ * Преобразува път от базата (/upload/filename.png) в URL за API route (/api/upload/filename.png).
+ * @param {string | null | undefined} path - Път от DB, напр. /upload/1767370010013.png
+ * @returns {string | null} URL за img src или null ако path е невалиден
+ */
+export function getUploadImageUrl(path) {
+  if (typeof path !== "string" || !path.trim()) return null;
+  const trimmed = path.trim();
+  if (!trimmed.startsWith("/upload/")) return null;
+  const filename = trimmed.slice("/upload/".length);
+  if (!filename) return null;
+  return `/api/upload/${filename}`;
+}

--- a/app/ReadArticles/ReadHTML.jsx
+++ b/app/ReadArticles/ReadHTML.jsx
@@ -11,6 +11,7 @@ import {
 import {fetchArticles} from "../../store/getArticles/getArticlesSlice";
 import LoaderHTML from "../loader/LoaderHTML";
 import SocialShare from "../Helper-components/socialShare/socialShare";
+import { getUploadImageUrl } from "../Helper-components/utils/imageUrl";
 
 const ReadHtml = () => {
     const dispatch = useDispatch();
@@ -146,7 +147,11 @@ const ReadHtml = () => {
                      {sectionArr.map((section, index) => (
                          <div key={index} className="read-section">
                              <h5 className="read-section-title text-align-center">{index + 1}.{section.title}</h5>
-                             {/*<p className="read-section-text">{section.content}</p>*/}
+                             {section.image_url && getUploadImageUrl(section.image_url) && (
+                                 <div className="article-image-container">
+                                     <img src={getUploadImageUrl(section.image_url)} alt={section.title} />
+                                 </div>
+                             )}
                              <ul>{formattedContent(section.content)}</ul>
                          </div>
                      ))}

--- a/app/api/upload/[...path]/route.ts
+++ b/app/api/upload/[...path]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import path from "path";
+import fs from "fs";
+
+const UPLOAD_DIR = path.join(process.cwd(), "upload");
+
+const MIME: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+};
+
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  const { path: pathSegments } = await context.params;
+  if (!pathSegments?.length) {
+    return NextResponse.json({ error: "Path required" }, { status: 400 });
+  }
+  const hasInvalidSegment = pathSegments.some(
+    (seg) => seg === "" || seg.includes("..")
+  );
+  if (hasInvalidSegment) {
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+  }
+
+  const filePath = path.join(UPLOAD_DIR, ...pathSegments);
+  const resolved = path.normalize(filePath);
+  if (!resolved.startsWith(UPLOAD_DIR)) {
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+  }
+
+  try {
+    const stat = await fs.promises.stat(resolved);
+    if (!stat.isFile()) {
+      return NextResponse.json({ error: "Not a file" }, { status: 404 });
+    }
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT") {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    return NextResponse.json(
+      { error: "Server error" },
+      { status: 500 }
+    );
+  }
+
+  const ext = path.extname(resolved).toLowerCase();
+  const contentType = MIME[ext] ?? "application/octet-stream";
+
+  const stream = fs.createReadStream(resolved);
+  return new NextResponse(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "public, max-age=86400",
+    },
+  });
+}

--- a/app/api/upload/[...path]/route.ts
+++ b/app/api/upload/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import path from "path";
 import fs from "fs";
+import { Readable } from "stream";
 
 const UPLOAD_DIR = path.join(process.cwd(), "upload");
 
@@ -53,8 +54,10 @@ export async function GET(
   const ext = path.extname(resolved).toLowerCase();
   const contentType = MIME[ext] ?? "application/octet-stream";
 
-  const stream = fs.createReadStream(resolved);
-  return new NextResponse(stream, {
+  const nodeStream = fs.createReadStream(resolved);
+  const webStream = Readable.toWeb(nodeStream) as unknown as ReadableStream<Uint8Array>;
+
+  return new NextResponse(webStream, {
     status: 200,
     headers: {
       "Content-Type": contentType,

--- a/app/cardAquariums/CardAquariumsHTML.jsx
+++ b/app/cardAquariums/CardAquariumsHTML.jsx
@@ -1,131 +1,157 @@
-'use client';
+"use client";
 
-import React, { Suspense, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import './cardAquariums.scss';
-import { useDispatch, useSelector } from 'react-redux';
-import images from '../../assets/images/image';
-import { fetchArticles } from '../../store/getArticles/getArticlesSlice';
+import React, {Suspense, useEffect} from "react";
+import {useRouter} from "next/navigation";
+import "./cardAquariums.scss";
+import {useDispatch, useSelector} from "react-redux";
+import images from "../../assets/images/image";
+import {getUploadImageUrl} from "../Helper-components/utils/imageUrl";
+import {fetchArticles} from "../../store/getArticles/getArticlesSlice";
 import {t} from "i18next";
 import LoaderHTML from "../loader/LoaderHTML";
 
 const CardAquariumsHTML = () => {
- const dispatch = useDispatch();
-setTimeout(() => {
- // const { t } = useTranslation();
-},2000)
- const router = useRouter();
- const status = useSelector((state) => state.articles.status);
- useEffect(() => {
-  if (status === 'idle') {
-   dispatch(fetchArticles());
-  }
- }, [status, dispatch]);
- const loading = useSelector((state) => state.articles);
- const articlesInfo = useSelector((state) => state.articles.data);
- let img = images;
- if (articlesInfo.length === 0 && status === 'failed') {
-  router.push('/');
- }
- const backToHome = () => {
-    router.push('/');
- }
- const handleClick = (id) => {
-  // const {id} = router.query;
-  // Проверете дали използвате низове за query параметрите
-  router.push('/ReadArticles' + `/?id=${id}`);
- };
- const sections = [
-  {
-   backgroundImage: `${img[8].url.src}`,
-   text: 'Immerse yourself in a seamless experience where every touchpoint anticipates your needs. Description one.',
-   date: '2024-12-13',
-  },
- ];
- return (
-  <Suspense fallback={<div>Loading...</div>}>
-   {
-    loading.isLoading ?
-        <LoaderHTML />:
-     <div>
-      <section
-       className="flex flex-col  justify-center items-center  add-scroll-aquarium-page">
-       <div
-        className="prose text-gray-500 prose-sm prose-headings:font-normal prose-headings:text-xl mobile-devices-styles">
-        <div className="flex-vertical-container-raw justify-center align-items-center">
-         <h4 className="text-align-center color-white">"Подводна магия у дома: Всичко за аквариуми – от старта до тайните на професионалистите"</h4>
-         <p className="text-balance color-white">"Живот под стъклото: Тайният свят на аквариумите, който ще ви плени"</p>
-        </div>
-       </div>
-
-       <div className="flex flex-wrap mx-auto mt-6 border-t pt-12">
+    const dispatch = useDispatch();
+    setTimeout(() => {
+        // const { t } = useTranslation();
+    }, 2000);
+    const router = useRouter();
+    const status = useSelector((state) => state.articles.status);
+    useEffect(() => {
+        if (status === "idle") {
+            dispatch(fetchArticles());
+        }
+    }, [status, dispatch]);
+    const loading = useSelector((state) => state.articles);
+    const articlesInfo = useSelector((state) => state.articles.data);
+    let img = images;
+    if (articlesInfo.length === 0 && status === "failed") {
+        router.push("/");
+    }
+    const backToHome = () => {
+        router.push("/");
+    };
+    const handleClick = (id) => {
+        // const {id} = router.query;
+        // Проверете дали използвате низове за query параметрите
+        router.push("/ReadArticles" + `/?id=${id}`);
+    };
+    const sections = [
         {
-         articlesInfo.length > 0 ?
-          (
+            backgroundImage: `${img[8].url.src}`,
+            text: "Immerse yourself in a seamless experience where every touchpoint anticipates your needs. Description one.",
+            date: "2024-12-13",
+        },
+    ];
+    return (
+        <Suspense fallback={<div>Loading...</div>}>
+            {
+                loading.isLoading ?
+                    <LoaderHTML/> :
+                    <div>
+                        <section
+                            className="flex flex-col  justify-center items-center  add-scroll-aquarium-page">
+                            <div
+                                className="prose text-gray-500 prose-sm prose-headings:font-normal prose-headings:text-xl mobile-devices-styles">
+                                <div
+                                    className="flex-vertical-container-raw justify-center align-items-center">
+                                    <h4 className="text-align-center color-white">"Подводна
+                                        магия у дома: Всичко за аквариуми – от
+                                        старта до тайните на
+                                        професионалистите"</h4>
+                                    <p className="text-balance color-white">"Живот
+                                        под стъклото: Тайният свят на
+                                        аквариумите, който ще ви плени"</p>
+                                </div>
+                            </div>
 
-           articlesInfo.map((article, index) => {
-            if (article.status === false) {
-             backToHome();
-            }
-            return (
-             <div key={index}>
-              {article.status === true && articlesInfo.length > 0 ?
-               <div className="blog-card margin-15" key={index}>
-                <div className="meta">
-                 <div className="photo" style={{ backgroundImage: `url(${img[7].url.src})` }}></div>
-                 <ul className="details">
-                  <li className="author">
-                   <a>{article.title.substring(0, 60)}....</a></li>
-                  <li className="date">{article.create_article_date}</li>
-                  <li className="tags">
-                   <ul>
-                    <li className="support-fish-aquarium">{t('Support')}</li>,
-                    <li className="support-fish">{t('Fish')}</li>,
-                    <li className="support-aquarium">{t('Aquarium')}</li>
-                   </ul>
-                  </li>
-                 </ul>
-                </div>
-                <div className="description">
-                 <h1>{article.title}</h1>
-                 <h5>Вашето ръководство за създаване и поддръжка на здрав и
-                  красив
-                  аквариум.</h5>
-                 {
-                  index === 0 ?
-                      <span>Аквариумите не са просто декорация, а живи екосистеми, които
+                            <div
+                                className="flex flex-wrap mx-auto mt-6 border-t pt-12">
+                                {
+                                    articlesInfo.length > 0 ?
+                                        (
+
+                                            articlesInfo.map((article, index) => {
+                                                if (article.status === false) {
+                                                    backToHome();
+                                                }
+                                                return (
+                                                    <div key={index}>
+                                                        {article.status === true && articlesInfo.length > 0 ?
+                                                            <div
+                                                                className="blog-card margin-15"
+                                                                key={index}>
+                                                                <div
+                                                                    className="meta">
+                                                                    <div
+                                                                        className="photo"
+                                                                        style={{backgroundImage: `url(${getUploadImageUrl(article.images) || img[7].url.src})`}}></div>
+                                                                    <ul className="details">
+                                                                        <li className="author">
+                                                                            <a>{article.title.substring(0, 60)}....</a>
+                                                                        </li>
+                                                                        <li className="date">{article.create_article_date}</li>
+                                                                        <li className="tags">
+                                                                            <ul>
+                                                                                <li className="support-fish-aquarium">{t("Support")}</li>
+                                                                                ,
+                                                                                <li className="support-fish">{t("Fish")}</li>,
+                                                                                <li className="support-aquarium">{t("Aquarium")}</li>
+                                                                            </ul>
+                                                                        </li>
+                                                                    </ul>
+                                                                </div>
+                                                                <div
+                                                                    className="description">
+                                                                    <h1>{article.title}</h1>
+                                                                    <h5>Вашето
+                                                                        ръководство
+                                                                        за
+                                                                        създаване
+                                                                        и
+                                                                        поддръжка
+                                                                        на здрав
+                                                                        и
+                                                                        красив
+                                                                        аквариум.</h5>
+                                                                    {
+                                                                        index === 0 ?
+                                                                            <span>Аквариумите не са просто декорация, а живи екосистеми, които
                   внасят спокойствие и красота в дома. Те обаче изискват знания,
                   внимание и грижи. Ако мечтаете за аквариум, но не знаете
                   откъде
                   да започнете, тази статия ще ви даде основни насоки.</span>
-                        :
-                      <span>{article.sections[index - 1].content.substring(0,220)}...</span>
-                 }
-                 <div className="flex-horizontal-container-raw justify-end">
-                  <button onClick={() => handleClick(article.id)}>
+                                                                            :
+                                                                            <span>{article.sections[index - 1].content.substring(0, 220)}...</span>
+                                                                    }
+                                                                    <div
+                                                                        className="flex-horizontal-container-raw justify-end">
+                                                                        <button
+                                                                            onClick={() => handleClick(article.id)}>
                    <span className="read-more">
-                    <a>{t('seeMore')}</a>
+                    <a>{t("seeMore")}</a>
                    </span>
-                  </button>
-                 </div>
-                </div>
-               </div> :
-               <div className="status-article-false"></div>
-              }
-             </div>
-            );
-           })
-          ) : null
-        }
+                                                                        </button>
+                                                                    </div>
+                                                                </div>
+                                                            </div> :
+                                                            <div
+                                                                className="status-article-false"></div>
+                                                        }
+                                                    </div>
+                                                );
+                                            })
+                                        ) : null
+                                }
 
-       </div>
-      </section>
+                            </div>
+                        </section>
 
-     </div>
+                    </div>
 
-   }
-  </Suspense>
- );
+            }
+        </Suspense>
+    );
 };
 
 export default CardAquariumsHTML;


### PR DESCRIPTION
feature/MB-37 Add a Next.js API route to serve files from the upload/ volume (/api/upload/[...path]) with MIME types, Cache-Control, and path traversal protection. Introduce getUploadImageUrl helper to map DB paths (/upload/...) to the API URL and update CardAquariumsHTML and ReadHTML to display uploaded images (with fallback to existing assets). Add documentation for the upload images plan and update plans index. Also add a GitHub Actions CI/CD workflow (lint, test, build, deploy, healthcheck).